### PR TITLE
Add ProductionEnvironmentUrl parameter to commands

### DIFF
--- a/PfMultiplayerCmdlets/AddPFMultiplayerAsset.cs
+++ b/PfMultiplayerCmdlets/AddPFMultiplayerAsset.cs
@@ -35,7 +35,7 @@
                 throw new Exception($"File {FilePath} does not exist");
             }
 
-            GetAssetUploadUrlResponse response = CallPlayFabApi(() => PlayFabMultiplayerAPI
+            GetAssetUploadUrlResponse response = CallPlayFabApi(() => Instance
                 .GetAssetUploadUrlAsync(new GetAssetUploadUrlRequest {FileName = AssetName ?? Path.GetFileName(FilePath)}));
 
             WriteVerbose($"SasToken retrieved {response.AssetUploadUrl}, uploading file.");

--- a/PfMultiplayerCmdlets/AddPFMultiplayerCertificate.cs
+++ b/PfMultiplayerCmdlets/AddPFMultiplayerCertificate.cs
@@ -28,7 +28,7 @@
             var certBytes = File.ReadAllBytes(FilePath);
             var certBase64 = Convert.ToBase64String(certBytes);
 
-            CallPlayFabApi(() => PlayFabMultiplayerAPI
+            CallPlayFabApi(() => Instance
                 .UploadCertificateAsync(new UploadCertificateRequest
                 {
                     GameCertificate = new Certificate {Base64EncodedValue = certBase64, Name = Name, Password = Password}

--- a/PfMultiplayerCmdlets/EnablePFMultiplayerServer.cs
+++ b/PfMultiplayerCmdlets/EnablePFMultiplayerServer.cs
@@ -14,7 +14,7 @@
 
         protected override void ProcessRecord()
         {
-            PlayFabMultiplayerAPI.EnableMultiplayerServersForTitleAsync(new EnableMultiplayerServersForTitleRequest()).Wait();
+            Instance.EnableMultiplayerServersForTitleAsync(new EnableMultiplayerServersForTitleRequest()).Wait();
             TitleMultiplayerServerEnabledStatus status = GetStatus();
             Stopwatch stopwatch = Stopwatch.StartNew();
             while (status != TitleMultiplayerServerEnabledStatus.Enabled)
@@ -29,7 +29,7 @@
 
         private TitleMultiplayerServerEnabledStatus GetStatus()
         {
-            return CallPlayFabApi( () => PlayFabMultiplayerAPI.GetTitleEnabledForMultiplayerServersStatusAsync(new GetTitleEnabledForMultiplayerServersStatusRequest()))
+            return CallPlayFabApi( () => Instance.GetTitleEnabledForMultiplayerServersStatusAsync(new GetTitleEnabledForMultiplayerServersStatusRequest()))
                 .Status.Value;
         }
     }

--- a/PfMultiplayerCmdlets/GetPFMultiplayerAsset.cs
+++ b/PfMultiplayerCmdlets/GetPFMultiplayerAsset.cs
@@ -13,14 +13,14 @@
         protected override void ProcessRecord()
         {
             List<AssetSummary> summaries = new List<AssetSummary>();
-            ListAssetSummariesResponse response = PlayFabMultiplayerAPI
+            ListAssetSummariesResponse response = Instance
                 .ListAssetSummariesAsync(new ListAssetSummariesRequest() {PageSize = DefaultPageSize}).Result.Result;
             summaries.AddRange(response.AssetSummaries ?? Enumerable.Empty<AssetSummary>());
             if (All)
             {
                 while (!string.IsNullOrEmpty(response.SkipToken))
                 {
-                    response = CallPlayFabApi(() => PlayFabMultiplayerAPI
+                    response = CallPlayFabApi(() => Instance
                         .ListAssetSummariesAsync(new ListAssetSummariesRequest() {PageSize = DefaultPageSize, SkipToken = response.SkipToken}));
                     summaries.AddRange(response.AssetSummaries ?? Enumerable.Empty<AssetSummary>());
                 }

--- a/PfMultiplayerCmdlets/GetPFMultiplayerBuild.cs
+++ b/PfMultiplayerCmdlets/GetPFMultiplayerBuild.cs
@@ -72,20 +72,20 @@
 
         private GetBuildResponse GetBuildDetails(string buildId)
         {
-            return CallPlayFabApi(() => PlayFabMultiplayerAPI.GetBuildAsync(new GetBuildRequest() {BuildId = buildId}));
+            return CallPlayFabApi(() => Instance.GetBuildAsync(new GetBuildRequest() {BuildId = buildId}));
         }
 
-        internal static List<BuildSummary> GetBuildSummaries(bool all)
+        internal List<BuildSummary> GetBuildSummaries(bool all)
         {
             List<BuildSummary> summaries = new List<BuildSummary>();
-            ListBuildSummariesResponse response = CallPlayFabApi(() => PlayFabMultiplayerAPI
+            ListBuildSummariesResponse response = CallPlayFabApi(() => Instance
                 .ListBuildSummariesAsync(new ListBuildSummariesRequest() { PageSize = DefaultPageSize }));
             summaries.AddRange(response.BuildSummaries ?? Enumerable.Empty<BuildSummary>());
             if (all)
             {
                 while (!string.IsNullOrEmpty(response.SkipToken))
                 {
-                    response = CallPlayFabApi(() => PlayFabMultiplayerAPI
+                    response = CallPlayFabApi(() => Instance
                         .ListBuildSummariesAsync(new ListBuildSummariesRequest() { PageSize = DefaultPageSize, SkipToken = response.SkipToken }));
                     summaries.AddRange(response.BuildSummaries ?? Enumerable.Empty<BuildSummary>());
                 }

--- a/PfMultiplayerCmdlets/GetPFMultiplayerCertificate.cs
+++ b/PfMultiplayerCmdlets/GetPFMultiplayerCertificate.cs
@@ -13,14 +13,14 @@
         protected override void ProcessRecord()
         {
             List<CertificateSummary> summaries = new List<CertificateSummary>();
-            ListCertificateSummariesResponse response = CallPlayFabApi(() => PlayFabMultiplayerAPI
+            ListCertificateSummariesResponse response = CallPlayFabApi(() => Instance
                 .ListCertificateSummariesAsync(new ListCertificateSummariesRequest() { PageSize = DefaultPageSize }));
             summaries.AddRange(response.CertificateSummaries ?? Enumerable.Empty<CertificateSummary>());
             if (All)
             {
                 while (!string.IsNullOrEmpty(response.SkipToken))
                 {
-                    response = CallPlayFabApi(() =>PlayFabMultiplayerAPI
+                    response = CallPlayFabApi(() => Instance
                         .ListCertificateSummariesAsync(new ListCertificateSummariesRequest() { PageSize = DefaultPageSize, SkipToken = response.SkipToken }));
                     summaries.AddRange(response.CertificateSummaries ?? Enumerable.Empty<CertificateSummary>());
                 }

--- a/PfMultiplayerCmdlets/GetPFMultiplayerQosServer.cs
+++ b/PfMultiplayerCmdlets/GetPFMultiplayerQosServer.cs
@@ -7,11 +7,11 @@
 
     [Cmdlet(VerbsCommon.Get, "PFMultiplayerQosServer")]
     [OutputType(typeof(List<QosServer>))]
-    public class GetPFMultiplayerQosServer : Cmdlet
+    public class GetPFMultiplayerQosServer : PageableCmdlet
     {
         protected override void ProcessRecord()
         {
-            ListQosServersResponse response = PlayFabMultiplayerAPI.ListQosServersAsync(new ListQosServersRequest()).Result.Result;
+            ListQosServersResponse response = Instance.ListQosServersAsync(new ListQosServersRequest()).Result.Result;
             WriteObject(response.QosServers);
         }
     }

--- a/PfMultiplayerCmdlets/GetPFMultiplayerServer.cs
+++ b/PfMultiplayerCmdlets/GetPFMultiplayerServer.cs
@@ -35,12 +35,12 @@
                 throw new ArgumentException("Exactly one of Regions, AllRegions should be specified.");
             }
 
-            string buildIdString = NewPFMultiplayerServer.GetBuildId(BuildName, BuildId);
+            string buildIdString = new NewPFMultiplayerServer { ProductionEnvironmentUrl = ProductionEnvironmentUrl }.GetBuildId(BuildName, BuildId);
 
             HashSet<AzureRegion> regionsList = new HashSet<AzureRegion>();
             if (AllRegions)
             {
-                GetBuildResponse response = PlayFabMultiplayerAPI.GetBuildAsync(new GetBuildRequest() {BuildId = buildIdString}).Result.Result;
+                GetBuildResponse response = Instance.GetBuildAsync(new GetBuildRequest() { BuildId = buildIdString }).Result.Result;
                 response.RegionConfigurations.ForEach(x => regionsList.Add(x.Region.Value));
             }
             else
@@ -53,21 +53,21 @@
             {
                 serverSummaries.AddRange(GetMultiplayerServers(buildIdString, region));
             }
-            
+
             WriteObject(serverSummaries);
         }
 
         private List<MultiplayerServerSummary> GetMultiplayerServers(string buildId, AzureRegion region)
         {
             List<MultiplayerServerSummary> summaries = new List<MultiplayerServerSummary>();
-            ListMultiplayerServersResponse response = CallPlayFabApi(() =>PlayFabMultiplayerAPI
-                .ListMultiplayerServersAsync(new ListMultiplayerServersRequest() {PageSize = DefaultPageSize, Region = region, BuildId = buildId}));
+            ListMultiplayerServersResponse response = CallPlayFabApi(() => Instance
+                .ListMultiplayerServersAsync(new ListMultiplayerServersRequest() { PageSize = DefaultPageSize, Region = region, BuildId = buildId }));
             summaries.AddRange(response.MultiplayerServerSummaries ?? Enumerable.Empty<MultiplayerServerSummary>());
             if (All)
             {
                 while (!string.IsNullOrEmpty(response.SkipToken))
                 {
-                    response = CallPlayFabApi(() => PlayFabMultiplayerAPI
+                    response = CallPlayFabApi(() => Instance
                         .ListMultiplayerServersAsync(new ListMultiplayerServersRequest()
                         {
                             BuildId = buildId,

--- a/PfMultiplayerCmdlets/NewPFMultiplayerBuild.cs
+++ b/PfMultiplayerCmdlets/NewPFMultiplayerBuild.cs
@@ -55,7 +55,7 @@
                 RegionConfigurations = RegionConfiguration
             };
 
-            CreateBuildWithManagedContainerResponse response = CallPlayFabApi(() => PlayFabMultiplayerAPI.CreateBuildWithManagedContainerAsync(buildRequest));
+            CreateBuildWithManagedContainerResponse response = CallPlayFabApi(() => Instance.CreateBuildWithManagedContainerAsync(buildRequest));
             WriteVerbose($"Created build {BuildName}");
             WriteObject(response);
         }

--- a/PfMultiplayerCmdlets/NewPFMultiplayerServer.cs
+++ b/PfMultiplayerCmdlets/NewPFMultiplayerServer.cs
@@ -1,11 +1,10 @@
 ﻿namespace PFMultiplayerCmdlets
 {
+    using PlayFab.MultiplayerModels;
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Management.Automation;
-    using PlayFab;
-    using PlayFab.MultiplayerModels;
 
     [Cmdlet(VerbsCommon.New, "PFMultiplayerServer")]
     public class NewPFMultiplayerServer : PFBaseCmdlet
@@ -26,12 +25,12 @@
         [ValidateNotNullOrEmpty]
         public List<AzureRegion> PreferredRegions { get; set; }
 
-        internal static string GetBuildId(string buildName, Guid? buildId)
+        internal string GetBuildId(string buildName, Guid? buildId)
         {
             ValidateBuildArguments(buildName, buildId);
             if (!string.IsNullOrEmpty(buildName))
             {
-                List<BuildSummary> buildSummaries = GetPFMultiplayerBuild.GetBuildSummaries(all: true);
+                List<BuildSummary> buildSummaries = new GetPFMultiplayerBuild { ProductionEnvironmentUrl = ProductionEnvironmentUrl }.GetBuildSummaries(all: true);
                 buildSummaries = buildSummaries.Where(x => x.BuildName.IndexOf(buildName, StringComparison.OrdinalIgnoreCase) > -1).ToList();
 
                 if (buildSummaries.Count == 0)
@@ -56,7 +55,7 @@
         {
             string buildIdString = GetBuildId(BuildName, BuildId);
 
-            RequestMultiplayerServerResponse response = CallPlayFabApi(() =>PlayFabMultiplayerAPI.RequestMultiplayerServerAsync(new RequestMultiplayerServerRequest()
+            RequestMultiplayerServerResponse response = CallPlayFabApi(() => Instance.RequestMultiplayerServerAsync(new RequestMultiplayerServerRequest()
             {
                 BuildId = buildIdString,
                 PreferredRegions = PreferredRegions,

--- a/PfMultiplayerCmdlets/PFBaseCmdlet.cs
+++ b/PfMultiplayerCmdlets/PFBaseCmdlet.cs
@@ -1,23 +1,47 @@
 ﻿namespace PFMultiplayerCmdlets
 {
-    using System;
-    using System.Management.Automation;
-    using System.Threading.Tasks;
     using Newtonsoft.Json;
     using PlayFab;
     using PlayFab.Internal;
+    using System;
+    using System.Management.Automation;
+    using System.Threading.Tasks;
 
     public class PFBaseCmdlet : PSCmdlet
     {
+        protected PlayFabMultiplayerInstanceAPI Instance { get; private set; }
+
+        [Parameter]
+        public string ProductionEnvironmentUrl { get; set; }
+
         protected override void BeginProcessing()
         {
             if (string.IsNullOrEmpty(PFTokenUtility.Instance.TitleId))
             {
                 throw new Exception("Run Set-PfTitle before running any cmdlet.");
             }
+
+            Instance = new PlayFabMultiplayerInstanceAPI(new PlayFabApiSettings
+            {
+                ProductionEnvironmentUrl = ProductionEnvironmentUrl ?? PlayFabSettings.staticSettings.ProductionEnvironmentUrl,
+                TitleId = PlayFabSettings.staticSettings.TitleId,
+                VerticalName = PlayFabSettings.staticSettings.VerticalName,
+                AdvertisingIdType = PlayFabSettings.staticSettings.AdvertisingIdType,
+                AdvertisingIdValue = PlayFabSettings.staticSettings.AdvertisingIdValue,
+                DeveloperSecretKey = PlayFabSettings.staticSettings.DeveloperSecretKey,
+                DisableAdvertising = PlayFabSettings.staticSettings.DisableAdvertising
+            }, GetAuthenticationContext());
         }
 
-        protected static T CallPlayFabApi<T>(Func<Task<PlayFabResult<T>>> apiCall) where T: PlayFabResultCommon
+        private PlayFabAuthenticationContext GetAuthenticationContext()
+        {
+            // Using reflection here since the property has an internal getter.
+            var fieldInfo = typeof(PlayFabSettings).GetField("staticPlayer", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            var context = (PlayFabAuthenticationContext)fieldInfo.GetValue(null);
+            return context;
+        }
+
+        protected static T CallPlayFabApi<T>(Func<Task<PlayFabResult<T>>> apiCall) where T : PlayFabResultCommon
         {
             try
             {
@@ -27,7 +51,7 @@
             {
                 throw new Exception(e.ToString());
             }
-            
+
             PlayFabResult<T> result = apiCall().Result;
             if (result.Error != null)
             {

--- a/PfMultiplayerCmdlets/PFTokenUtility.cs
+++ b/PfMultiplayerCmdlets/PFTokenUtility.cs
@@ -39,8 +39,8 @@
                 fieldInfo = typeof(PlayFabAuthenticationContext).GetField("EntityToken", BindingFlags.Instance | BindingFlags.Public);
                 fieldInfo.SetValue(context, null);
                 
-                PlayFabSettings.TitleId = TitleId;
-                PlayFabSettings.DeveloperSecretKey = _secretKey;
+                PlayFabSettings.staticSettings.TitleId = TitleId;
+                PlayFabSettings.staticSettings.DeveloperSecretKey = _secretKey;
 
                 // The SDK sets the entity token as part of response evaluation.
                 PlayFabAuthenticationAPI.GetEntityTokenAsync(request).Wait();

--- a/PfMultiplayerCmdlets/RemovePFMultiplayerAsset.cs
+++ b/PfMultiplayerCmdlets/RemovePFMultiplayerAsset.cs
@@ -12,7 +12,7 @@
 
         protected override void ProcessRecord()
         {
-            CallPlayFabApi(() => PlayFabMultiplayerAPI.DeleteAssetAsync(new DeleteAssetRequest() {FileName = FileName}));
+            CallPlayFabApi(() => Instance.DeleteAssetAsync(new DeleteAssetRequest() {FileName = FileName}));
             WriteVerbose($"Completed removing asset {FileName}.");
         }
     }

--- a/PfMultiplayerCmdlets/RemovePFMultiplayerBuild.cs
+++ b/PfMultiplayerCmdlets/RemovePFMultiplayerBuild.cs
@@ -13,7 +13,7 @@
 
         protected override void ProcessRecord()
         {
-            CallPlayFabApi(() => PlayFabMultiplayerAPI.DeleteBuildAsync(new DeleteBuildRequest() {BuildId = BuildId.Value.ToString()}));
+            CallPlayFabApi(() => Instance.DeleteBuildAsync(new DeleteBuildRequest() {BuildId = BuildId.Value.ToString()}));
             WriteVerbose($"Build {BuildId.Value} is marked for deletion.");
         }
     }

--- a/PfMultiplayerCmdlets/RemovePFMultiplayerCertificate.cs
+++ b/PfMultiplayerCmdlets/RemovePFMultiplayerCertificate.cs
@@ -12,7 +12,7 @@
 
         protected override void ProcessRecord()
         {
-            CallPlayFabApi(() => PlayFabMultiplayerAPI.DeleteCertificateAsync(new DeleteCertificateRequest {Name = Name}));
+            CallPlayFabApi(() => Instance.DeleteCertificateAsync(new DeleteCertificateRequest {Name = Name}));
             WriteVerbose($"Completed removing certificate {Name}.");
         }
     }


### PR DESCRIPTION
Use a `PlayFabMultiplayerInstanceAPI` instance to be able to specify the API URL.
Also deriving from `GetPFMultiplayerQosServer` from `PageableCmdlet`, as it seemed to be like other commands that require `SetPFTitle` before being able to work.
